### PR TITLE
Updating GO api to use non-encoding json return from forked verion of…

### DIFF
--- a/go-api/go.mod
+++ b/go-api/go.mod
@@ -9,6 +9,8 @@ require (
 )
 
 require (
+	github.com/AndrewBewseyTNA/echo-swagger v0.0.0-20230403103356-3aa67e30e23a // indirect
+	github.com/AndrewBewseyTNA/echo/v4 v4.0.0-20230403085805-b70769f7e765 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.0 // indirect
@@ -39,7 +41,8 @@ require (
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/swaggo/files v1.0.1 // indirect
-	github.com/swaggo/swag v1.8.11 // indirect
+	github.com/swaggo/files/v2 v2.0.0 // indirect
+	github.com/swaggo/swag v1.8.12 // indirect
 	github.com/urfave/cli/v2 v2.3.0 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/tools v0.7.0 // indirect

--- a/go-api/go.sum
+++ b/go-api/go.sum
@@ -1,3 +1,7 @@
+github.com/AndrewBewseyTNA/echo-swagger v0.0.0-20230403103356-3aa67e30e23a h1:drLNR9KgA3yggwHUVp0sz0+vkpptJuCIRhGkdhDtt0c=
+github.com/AndrewBewseyTNA/echo-swagger v0.0.0-20230403103356-3aa67e30e23a/go.mod h1:Liho6T8COJxbVLG8CMXXt9kupGYCnpcnJhIeWnX1fdM=
+github.com/AndrewBewseyTNA/echo/v4 v4.0.0-20230403085805-b70769f7e765 h1:LSoMbBzmE/GDWN5ObQVZtyplqJDa1+irRKOeNB/bOAE=
+github.com/AndrewBewseyTNA/echo/v4 v4.0.0-20230403085805-b70769f7e765/go.mod h1:VzdU5LO3mCTEC2Wkcv3owgbmceIiYStrn1m1xw8QdJo=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -184,9 +188,13 @@ github.com/swaggo/files v0.0.0-20220728132757-551d4a08d97a h1:kAe4YSu0O0UFn1DowN
 github.com/swaggo/files v0.0.0-20220728132757-551d4a08d97a/go.mod h1:lKJPbtWzJ9JhsTN1k1gZgleJWY/cqq0psdoMmaThG3w=
 github.com/swaggo/files v1.0.1 h1:J1bVJ4XHZNq0I46UU90611i9/YzdrF7x92oX1ig5IdE=
 github.com/swaggo/files v1.0.1/go.mod h1:0qXmMNH6sXNf+73t65aKeB+ApmgxdnkQzVTAj2uaMUg=
+github.com/swaggo/files/v2 v2.0.0 h1:hmAt8Dkynw7Ssz46F6pn8ok6YmGZqHSVLZ+HQM7i0kw=
+github.com/swaggo/files/v2 v2.0.0/go.mod h1:24kk2Y9NYEJ5lHuCra6iVwkMjIekMCaFq/0JQj66kyM=
 github.com/swaggo/swag v1.8.1/go.mod h1:ugemnJsPZm/kRwFUnzBlbHRd0JY9zE1M4F+uy2pAaPQ=
 github.com/swaggo/swag v1.8.11 h1:Fp1dNNtDvbCf+8kvehZbHQnlF6AxHGjmw6H/xAMrZfY=
 github.com/swaggo/swag v1.8.11/go.mod h1:2GXgpNI9iy5OdsYWu8zXfRAGnOAPxYxTWTyM0XOTYZQ=
+github.com/swaggo/swag v1.8.12 h1:pctzkNPu0AlQP2royqX3apjKCQonAnf7KGoxeO4y64w=
+github.com/swaggo/swag v1.8.12/go.mod h1:lNfm6Gg+oAq3zRJQNEMBE66LIJKM44mxFqhEEgy2its=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=

--- a/go-api/main.go
+++ b/go-api/main.go
@@ -12,10 +12,10 @@ import (
 	"strconv"
 	"strings"
 
+	echoSwagger "github.com/AndrewBewseyTNA/echo-swagger"
+	"github.com/AndrewBewseyTNA/echo/v4"
+	"github.com/AndrewBewseyTNA/echo/v4/middleware"
 	_ "github.com/OurHeritageOurStories/ohos-neptune-ec2-api/docs"
-	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
-	echoSwagger "github.com/swaggo/echo-swagger"
 )
 
 func max(a, b int) int {
@@ -60,7 +60,7 @@ type TitleTopicUrlDescriptionBindingStruct struct {
 }
 
 type BindingsTitleTopicUrlDescription struct {
-	Identifier 	IdentifierReturnValues
+	Identifier  IdentifierReturnValues
 	Title       TitleTopicStructValues
 	Description TitleTopicStructValues
 	URL         URLReturnValues
@@ -74,8 +74,8 @@ type URLReturnValues struct {
 }
 
 type IdentifierReturnValues struct {
-	Type     string `json:"type"`
-	Value    string `json:"value"`
+	Type  string `json:"type"`
+	Value string `json:"value"`
 }
 
 // struct for results for title/topic search
@@ -186,7 +186,7 @@ func buildMainSparqlQuery(keyword string, offset string) string {
 }
 
 func buildEntityMainSparqlQuery(id string) string {
-	titleTopicURLDescription := "prefix ns0: <http://id.loc.gov/ontologies/bibframe/> prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> prefix xsd: <http://www.w3.org/2001/XMLSchema#> prefix ns1: <http://id.loc.gov/ontologies/bflc/> prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> select ('"+id+"' as ?identifier) ?title ?url ?description (group_concat(?topic;separator=' ||| ')as ?topics) where {?s ns0:title _:title ._:title ns0:mainTitle ?title .?s ns0:summary _:summary ._:summary rdfs:label ?description .?s ns0:subject _:subject ._:subject rdfs:label ?topic .?s ns0:hasInstance ?t .?t ns0:hasItem ?r .?r ns0:electronicLocator _:url ._:url rdf:value ?url .?s ns0:adminMetadata _:adminData ._:adminData ns0:identifiedBy _:identifiedBy ._:identifiedBy rdf:value '"+id+"' .} group by ?title ?description ?url order by ?title OFFSET 0 limit 10"
+	titleTopicURLDescription := "prefix ns0: <http://id.loc.gov/ontologies/bibframe/> prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> prefix xsd: <http://www.w3.org/2001/XMLSchema#> prefix ns1: <http://id.loc.gov/ontologies/bflc/> prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> select ('" + id + "' as ?identifier) ?title ?url ?description (group_concat(?topic;separator=' ||| ')as ?topics) where {?s ns0:title _:title ._:title ns0:mainTitle ?title .?s ns0:summary _:summary ._:summary rdfs:label ?description .?s ns0:subject _:subject ._:subject rdfs:label ?topic .?s ns0:hasInstance ?t .?t ns0:hasItem ?r .?r ns0:electronicLocator _:url ._:url rdf:value ?url .?s ns0:adminMetadata _:adminData ._:adminData ns0:identifiedBy _:identifiedBy ._:identifiedBy rdf:value '" + id + "' .} group by ?title ?description ?url order by ?title OFFSET 0 limit 10"
 	return titleTopicURLDescription
 }
 
@@ -453,7 +453,7 @@ func movingImages(c echo.Context) error {
 
 	jsonToReturn.Items = mainResultStruct.Results.Bindings
 
-	return c.JSONPretty(http.StatusOK, jsonToReturn, " ")
+	return c.JSONNonEncodePretty(http.StatusOK, jsonToReturn, " ")
 }
 
 // Moving Images Entity godoc
@@ -512,7 +512,7 @@ func movingImagesEntity(c echo.Context) error {
 
 	jsonToReturn.Items = mainResultStruct.Results.Bindings
 
-	return c.JSONPretty(http.StatusOK, jsonToReturn, " ")
+	return c.JSONNonEncodePretty(http.StatusOK, jsonToReturn, " ")
 }
 
 // @title OHOS api


### PR DESCRIPTION
… Echo.

This might be a slightly over the top way to do things (a fork of Echo and Echo swagger), but this is the fix I found. 