### PR TITLE
Ohos 1570 page number should not be mandatory in api

### DIFF
--- a/go-api/main.go
+++ b/go-api/main.go
@@ -334,13 +334,15 @@ func movingImages(ec2url, neptuneurl, movingImagesEndpoint string) echo.HandlerF
 		_, qPresent := userProvidedParams["q"]
 		_, pagePresent := userProvidedParams["page"]
 
-		if len(userProvidedParams) != 2 {
-			return c.String(http.StatusBadRequest, "You need to provide both a keyword (as q) and a page number")
-		} else if !qPresent || !pagePresent {
-			return c.String(http.StatusBadRequest, "You need to provide a keyword as q and a page as page. q needs to be a string, page needs to be an int. Copy this example"+ec2url+" /api/"+movingImagesEndpoint+"?q=glasgow&page=1")
+		if len(userProvidedParams) == 0 {
+			return c.String(http.StatusBadRequest, "You need to provide both a search term (as q) and a page number (as page). Copy this example "+ec2url+"/api/"+movingImagesEndpoint+"?q=glasgow&page=1")
+		} else if !qPresent && pagePresent {
+			return c.String(http.StatusBadRequest, "You need to provide a search term (as q). Copy this example "+ec2url+"/api/"+movingImagesEndpoint+"?q=glasgow&page=1")
 		} else {
+			if pagePresent {
+				pageKeyword = userProvidedParams.Get("page") //only get the new page number if its provided, else use the default
+			}
 			keyword = userProvidedParams.Get("q")
-			pageKeyword = userProvidedParams.Get("page")
 			jsonToReturn.Id.Keyword = keyword
 			jsonToReturn.Id.Page = pageKeyword
 		}

--- a/go-api/main.go
+++ b/go-api/main.go
@@ -310,7 +310,7 @@ func fetchDiscovery(discoveryapiurl string) echo.HandlerFunc {
 // @Description Moving images queries
 // @Tags MovingImages
 // @Param q query string true "string query"
-// @Param page query int true "int page"
+// @Param page query int false "int page"
 // @Produce json
 // @Success 200 {object} keywordReturnStruct
 // @Success 204


### PR DESCRIPTION
Instead of defaulting to "you must provide both parms", we now check in more detail what you've provided:

- If its nothing, then you get a message telling you to provide both params
- If you provide a page only, then you get a message saying you need to provide a search term
- If you provide provide a search term only, then the default page value of "1" is used
- If you provide both, then both are used

This also means an update to the docs - as page is no longer required, then becomes a "false" 